### PR TITLE
Define api request url in a more proper way using native "apiUrl" attribute.

### DIFF
--- a/js/src/forum/index.js
+++ b/js/src/forum/index.js
@@ -15,7 +15,7 @@ app.initializers.add('clarkwinkelmann/flarum-ext-poke', () => {
                 icon: 'fas fa-hand-point-left',
                 onclick: () => {
                     app.request({
-                        url: '/api/users/' + this.props.user.id() + '/poke',
+                        url: app.forum.attribute('apiUrl') + '/users/' + this.props.user.id() + '/poke',
                         method: 'POST',
                     }).then(data => {
                         app.store.pushPayload(data);
@@ -39,7 +39,7 @@ app.initializers.add('clarkwinkelmann/flarum-ext-poke', () => {
                 children: app.translator.trans('clarkwinkelmann-poke.forum.profile.reset'),
                 onclick() {
                     app.request({
-                        url: '/api/users/' + user.id() + '/poke-reset',
+                        url: app.forum.attribute('apiUrl') + '/users/' + user.id() + '/poke-reset',
                         method: 'POST',
                     }).then(() => {
                         alert(app.translator.trans('clarkwinkelmann-poke.forum.profile.reseted'));


### PR DESCRIPTION
I have installed the extension in my localhost subfolder (http://localhost/flarum/). When I clicked the poke (or reset poke count) button, the api request is instead made towards http://localhost and ended up with an 404 error. Thus, I think we should define the absolute url for the api request using Flarum's native apiUrl attribute.